### PR TITLE
Improve CMake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,47 @@
 cmake_minimum_required(VERSION 3.12)
 project(ThreadPool)
 
-add_library(ThreadPool OBJECT ThreadPool.cpp)
+include(GNUInstallDirs)
+
+set(CMAKE_INSTALL_CMAKEDIR "share/cmake" CACHE STRING "Install location for cmake related files")
+mark_as_advanced(CMAKE_INSTALL_CMAKEDIR)
+
+set(LIBRARY_TYPES "OBJECT;STATIC;SHARED")
+set(THREADPOOL_LIBRARY_TYPE "OBJECT" CACHE STRING "Choose the type of library to build, options are: ${LIBRARY_TYPES}.")
+set_property(CACHE THREADPOOL_LIBRARY_TYPE PROPERTY STRINGS ${LIBRARY_TYPES})
+if (NOT THREADPOOL_LIBRARY_TYPE IN_LIST LIBRARY_TYPES)
+  message(FATAL_ERROR "Invalid option: THREADPOOL_LIBRARY_TYPE=${THREADPOOL_LIBRARY_TYPE}. Supported options: ${LIBRARY_TYPES}.")
+endif()
+
+find_package(Threads REQUIRED)
+
+add_library(ThreadPool ${THREADPOOL_LIBRARY_TYPE} ThreadPool.cpp)
+target_link_libraries(ThreadPool PUBLIC Threads::Threads)
+
+target_include_directories(ThreadPool
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+         $<INSTALL_INTERFACE:include>)
+
 target_compile_features(ThreadPool PRIVATE cxx_std_17)
-target_include_directories(ThreadPool PUBLIC .)
+
+# Define public headers to get them automatically installed.
+set_target_properties(ThreadPool PROPERTIES
+  PUBLIC_HEADER "ThreadPool.hpp")
+
+set(THREADPOOL_EXPORT ThreadPoolConfig)
+
+# Install the lib and its headers. Flag it for export.
+install(
+  TARGETS ThreadPool
+  EXPORT ${THREADPOOL_EXPORT}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+# Create the export file for the build tree.
+export(TARGETS ThreadPool FILE "${PROJECT_BINARY_DIR}/${THREADPOOL_EXPORT}.cmake")
+
+# Create the export file for the install tree.
+install(EXPORT ${THREADPOOL_EXPORT}
+  DESTINATION "${CMAKE_INSTALL_CMAKEDIR}")

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 A simple C++17 Thread Pool implementation.
 
-Basic usage:
+## Basic usage
+
 ```c++
 // create thread pool with 4 worker threads
 ThreadPool pool(4);
@@ -13,4 +14,54 @@ auto result = pool.enqueue([](int answer) { return answer; }, 42);
 // get result from future
 std::cout << result.get() << std::endl;
 
+```
+
+## CMake
+
+### Build options
+
+- `THREADPOOL_LIBRARY_TYPE`: Set the type of library to build.
+
+    Supported options: `OBJECT` (default), `STATIC`, `SHARED`.
+
+### Import using `find_package`
+
+Build and install ThreadPool somewhere on your system (note: `OBJECT` libraries cannot be installed).
+
+```cmake
+find_package(Threads REQUIRED)
+
+set(ThreadPool_DIR "</threadpool/install/dir>/share/cmake")
+# You can actually skip the install step and use the build directory.
+set(ThreadPool_DIR "</threadpool/build/dir>")
+
+find_package(Threads REQUIRED)
+find_package(ThreadPool)
+
+target_link_libraries(<your-target> PRIVATE ThreadPool)
+```
+
+### Import using `FetchContent` (CMake >= 3.11)
+
+```cmake
+find_package(Threads REQUIRED)
+
+FetchContent_Declare(ThreadPool
+    GIT_REPOSITORY git://github.com/jhasse/ThreadPool.git
+)
+
+# Optional
+# set(THREADPOOL_LIBRARY_TYPE SHARED)
+
+# If CMake >= 3.14
+FetchContent_MakeAvailable(ThreadPool)
+
+# If CMake < 3.14
+FetchContent_GetProperties(ThreadPool)
+if (NOT ThreadPool_POPULATED)
+    FetchContent_Populate(ThreadPool)
+    add_subdirectory("${ThreadPool_SOURCE_DIR}" ${ThreadPool_BINARY_DIR})
+endif()
+
+target_link_libraries(<your-target> PRIVATE ThreadPool)
 ```


### PR DESCRIPTION
- Add option to choose between building an OBJECT, STATIC or SHARED
library.
- Make ThreadPool installable through CMake.
- Generate ThreadPoolConfig.cmake file to allow import from both build &
install directory.
- Add dependency to the Threads library.
- Add more details about CMake support in README.